### PR TITLE
Add TikTok direct post support with video.publish scope

### DIFF
--- a/auth_tiktok_token_manager.py
+++ b/auth_tiktok_token_manager.py
@@ -12,7 +12,7 @@ load_dotenv()
 CLIENT_KEY    = (os.getenv("TIKTOK_CLIENT_KEY") or "").strip()
 CLIENT_SECRET = (os.getenv("TIKTOK_CLIENT_SECRET") or "").strip()
 REDIRECT_URI  = (os.getenv("TIKTOK_REDIRECT_URI") or "http://127.0.0.1:53682/callback").strip()
-SCOPES        = (os.getenv("TIKTOK_SCOPES") or "user.info.basic,video.upload").strip()
+SCOPES        = (os.getenv("TIKTOK_SCOPES") or "user.info.basic,video.upload,video.publish").strip()
 
 # Optionnel: forcer le chemin de Firefox (Windows)
 FIREFOX_PATH  = (os.getenv("FIREFOX_PATH") or "").strip()  # ex: C:\Program Files\Mozilla Firefox\firefox.exe
@@ -191,6 +191,9 @@ def main():
     # Met à jour .env
     update_env_file("TIKTOK_USER_ACCESS_TOKEN", access_token)
     log("TIKTOK_USER_ACCESS_TOKEN mis à jour dans .env")
+    if refresh_token:
+        update_env_file("TIKTOK_USER_REFRESH_TOKEN", refresh_token)
+        log("TIKTOK_USER_REFRESH_TOKEN mis à jour dans .env")
 
     print("\nOK. Tu peux lancer:")
     print("python main.py --post-draft --draft-poll")

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mr Martin - Automated TikTok Video Creator</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; line-height: 1.6; }
+    .container { max-width: 800px; margin: 0 auto; padding: 40px 20px; }
+    h1 { font-size: 2.2rem; margin-bottom: 8px; }
+    .subtitle { color: #666; font-size: 1.1rem; margin-bottom: 40px; }
+    h2 { font-size: 1.4rem; margin: 32px 0 12px; }
+    p, li { font-size: 1rem; margin-bottom: 8px; }
+    ul { padding-left: 24px; margin-bottom: 16px; }
+    .links { margin-top: 40px; padding-top: 20px; border-top: 1px solid #e0e0e0; }
+    .links a { color: #0066cc; text-decoration: none; margin-right: 24px; }
+    .links a:hover { text-decoration: underline; }
+    footer { margin-top: 60px; color: #999; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Mr Martin</h1>
+    <p class="subtitle">Automated TikTok Video Creator &amp; Publisher</p>
+
+    <h2>About</h2>
+    <p>Mr Martin is a desktop application that automates the creation and publication of animated videos on TikTok. The application processes existing video content, generates animations, and publishes them directly to TikTok using the Content Posting API.</p>
+
+    <h2>Features</h2>
+    <ul>
+      <li>Automated video download and processing</li>
+      <li>Audio transcription with speaker diarization</li>
+      <li>AI-powered script rewriting and caption generation</li>
+      <li>Animated video generation via Adobe After Effects</li>
+      <li>Direct publishing to TikTok with captions</li>
+      <li>Respects creator privacy settings and interaction preferences</li>
+    </ul>
+
+    <h2>How it works</h2>
+    <p>The application authenticates with TikTok via OAuth (Login Kit) using a local redirect URI. Before each post, it queries the creator's account settings to ensure compliance with their privacy preferences. Videos are posted directly to the creator's profile with auto-generated captions, or sent to the inbox as drafts when direct posting is unavailable.</p>
+
+    <h2>TikTok Integration</h2>
+    <ul>
+      <li><strong>Login Kit</strong> &mdash; OAuth authentication with PKCE</li>
+      <li><strong>Content Posting API</strong> &mdash; Direct post (video.publish) and inbox upload (video.upload)</li>
+      <li><strong>Creator Info Query</strong> &mdash; Retrieves privacy levels and interaction settings before each post</li>
+    </ul>
+
+    <div class="links">
+      <a href="tos.html">Terms of Service</a>
+      <a href="privacy.html">Privacy Policy</a>
+    </div>
+
+    <footer>
+      <p>&copy; 2026 Mr Martin. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Mr Martin</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; line-height: 1.6; }
+    .container { max-width: 800px; margin: 0 auto; padding: 40px 20px; }
+    h1 { font-size: 2rem; margin-bottom: 8px; }
+    .date { color: #666; margin-bottom: 32px; }
+    h2 { font-size: 1.2rem; margin: 24px 0 8px; }
+    p { margin-bottom: 12px; }
+    a { color: #0066cc; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    footer { margin-top: 60px; color: #999; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Privacy Policy</h1>
+    <p class="date">Last updated: April 13, 2026</p>
+
+    <h2>1. Introduction</h2>
+    <p>This Privacy Policy explains how the Mr Martin application ("the App") collects, uses, and protects your information.</p>
+
+    <h2>2. Information We Collect</h2>
+    <p>The App collects only the minimum information necessary to function:</p>
+    <p>- <strong>TikTok OAuth tokens</strong>: access token and refresh token, stored locally on your computer in the <code>.env</code> file and <code>config/tiktok_tokens.json</code>.<br>
+       - <strong>Basic TikTok profile information</strong>: display name and avatar URL, retrieved via the TikTok API to verify your identity.<br>
+       - <strong>Creator account settings</strong>: privacy level options and interaction preferences, queried before each post to ensure compliance.</p>
+
+    <h2>3. How We Use Your Information</h2>
+    <p>Your information is used exclusively to:</p>
+    <p>- Authenticate with the TikTok API on your behalf<br>
+       - Publish videos to your TikTok account<br>
+       - Respect your account's privacy and interaction settings when posting</p>
+
+    <h2>4. Data Storage</h2>
+    <p>All data is stored locally on your computer. The App does not transmit your personal data to any server other than TikTok's official API endpoints. No data is stored in the cloud or shared with third parties.</p>
+
+    <h2>5. Third-Party Services</h2>
+    <p>The App interacts with the following third-party services:</p>
+    <p>- <strong>TikTok Content Posting API</strong>: to publish videos and query account settings<br>
+       - <strong>TikTok Login Kit</strong>: for OAuth authentication<br>
+       - <strong>AssemblyAI</strong>: for audio transcription (audio files are sent to their API for processing)<br>
+       - <strong>OpenAI</strong>: for AI-powered text generation (text data is sent to their API)</p>
+    <p>Each third-party service is governed by its own privacy policy.</p>
+
+    <h2>6. Data Retention</h2>
+    <p>OAuth tokens are stored locally until you revoke access or delete them. Video files and transcriptions are processed locally and can be deleted at any time by the user.</p>
+
+    <h2>7. Your Rights</h2>
+    <p>You can at any time:</p>
+    <p>- Revoke the App's access to your TikTok account via TikTok's settings<br>
+       - Delete all locally stored tokens and data<br>
+       - Uninstall the App entirely</p>
+
+    <h2>8. Data Security</h2>
+    <p>OAuth tokens are stored in local configuration files on your machine. We recommend keeping your computer secure and not sharing these files.</p>
+
+    <h2>9. Children's Privacy</h2>
+    <p>The App is not intended for use by anyone under the age of 18.</p>
+
+    <h2>10. Changes to This Policy</h2>
+    <p>We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated date.</p>
+
+    <h2>11. Contact</h2>
+    <p>For questions about this Privacy Policy, please contact us via <a href="https://github.com/namelaise/mr-martin-app">GitHub</a>.</p>
+
+    <p><a href="index.html">&larr; Back to homepage</a></p>
+
+    <footer>
+      <p>&copy; 2026 Mr Martin. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/docs/tos.html
+++ b/docs/tos.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service - Mr Martin</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; line-height: 1.6; }
+    .container { max-width: 800px; margin: 0 auto; padding: 40px 20px; }
+    h1 { font-size: 2rem; margin-bottom: 8px; }
+    .date { color: #666; margin-bottom: 32px; }
+    h2 { font-size: 1.2rem; margin: 24px 0 8px; }
+    p { margin-bottom: 12px; }
+    a { color: #0066cc; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    footer { margin-top: 60px; color: #999; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Terms of Service</h1>
+    <p class="date">Last updated: April 13, 2026</p>
+
+    <h2>1. Acceptance of Terms</h2>
+    <p>By using the Mr Martin application ("the App"), you agree to these Terms of Service. If you do not agree, do not use the App.</p>
+
+    <h2>2. Description of Service</h2>
+    <p>Mr Martin is a desktop application that automates video content creation and publication to TikTok. The App uses the TikTok Content Posting API to publish videos on behalf of authenticated users.</p>
+
+    <h2>3. TikTok Account Authorization</h2>
+    <p>The App requires you to authorize access to your TikTok account via TikTok's OAuth login. By authorizing, you grant the App permission to:</p>
+    <p>- Read your basic profile information (display name, avatar)<br>
+       - Upload videos to your TikTok inbox as drafts<br>
+       - Publish videos directly to your TikTok profile<br>
+       - Query your account's privacy and interaction settings</p>
+    <p>You may revoke access at any time through your TikTok account settings.</p>
+
+    <h2>4. User Responsibilities</h2>
+    <p>You are responsible for all content published through the App to your TikTok account. You agree not to use the App to publish content that violates TikTok's Community Guidelines or any applicable laws.</p>
+
+    <h2>5. Content Ownership</h2>
+    <p>You retain all rights to the content you create and publish using the App. The App does not claim ownership of any user-generated content.</p>
+
+    <h2>6. Privacy</h2>
+    <p>Please refer to our <a href="privacy.html">Privacy Policy</a> for information about how we handle your data.</p>
+
+    <h2>7. Disclaimer</h2>
+    <p>The App is provided "as is" without warranties of any kind. We are not responsible for any disruptions to TikTok's API services or changes to their platform that may affect the App's functionality.</p>
+
+    <h2>8. Limitation of Liability</h2>
+    <p>To the maximum extent permitted by law, the developers of Mr Martin shall not be liable for any indirect, incidental, or consequential damages arising from the use of the App.</p>
+
+    <h2>9. Changes to Terms</h2>
+    <p>We may update these Terms from time to time. Continued use of the App after changes constitutes acceptance of the new Terms.</p>
+
+    <h2>10. Contact</h2>
+    <p>For questions about these Terms, please contact us via <a href="https://github.com/namelaise/mr-martin-app">GitHub</a>.</p>
+
+    <p><a href="index.html">&larr; Back to homepage</a></p>
+
+    <footer>
+      <p>&copy; 2026 Mr Martin. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/main_v3.py
+++ b/main_v3.py
@@ -349,8 +349,14 @@ def stash_unposted_videos(
     return dest_dir
 
 
+def _detect_scope_not_authorized(blob: str) -> bool:
+    return "scope_not_authorized" in blob.lower()
+
+
 def _detect_token_issue(blob: str) -> bool:
     blob_low = blob.lower()
+    if "scope_not_authorized" in blob_low:
+        return False  # pas un problème de token, c'est un problème de scope
     return (
         "access_token_invalid" in blob_low
         or "http 401" in blob_low
@@ -377,19 +383,29 @@ def upload_to_tiktok_with_retry(final_mp4: str, python_exe: str = sys.executable
     log_path = LOG_DIR / "upload_tiktok.log"
     preflight_mp4_checks(final_mp4)
 
-    def _post():
+    def _post(direct: bool = True):
         cmd = [python_exe, "post_tiktok_inbox.py", "--video", final_mp4, "--poll"]
-        if caption:
+        if direct and caption:
             cmd.extend(["--direct", "--caption", caption])
         return run_cmd_capture(cmd, log_path)
 
-    # --- Tentative 1
-    rc, out, err = _post()
+    # --- Tentative 1 (DIRECT si caption)
+    rc, out, err = _post(direct=bool(caption))
     if rc == 0:
         log.info("📤 Upload TikTok OK (1er essai)")
         return True, "ok"
 
     blob = (out + "\n" + err)
+
+    # --- scope_not_authorized → fallback INBOX (scope video.publish non approuvé)
+    if _detect_scope_not_authorized(blob):
+        log.warning("⚠️ scope video.publish non autorisé → fallback en mode INBOX (brouillon)")
+        rc_fb, out_fb, err_fb = _post(direct=False)
+        if rc_fb == 0:
+            log.info("📤 Upload TikTok OK en mode INBOX (fallback)")
+            return True, "ok_inbox_fallback"
+        log.error("❌ Upload TikTok échoué même en mode INBOX. Voir logs/upload_tiktok.log")
+        return False, "other_failed"
 
     if _contains_spam_risk(blob):
         log.error(f"🚫 Upload TikTok refusé (spam risk): {TIKTOK_SPAM_RISK_KEY}")
@@ -400,11 +416,17 @@ def upload_to_tiktok_with_retry(final_mp4: str, python_exe: str = sys.executable
         log.warning("🔐 Token TikTok possiblement invalide → rafraîchissement…")
         if not _refresh_token_ok(python_exe, log_path):
             return False, "token_failed"
-        rc2, out2, err2 = _post()
+        rc2, out2, err2 = _post(direct=bool(caption))
         if rc2 == 0:
             log.info("📤 Upload TikTok OK après refresh token")
             return True, "ok"
         blob2 = (out2 + "\n" + err2)
+        if _detect_scope_not_authorized(blob2):
+            log.warning("⚠️ scope video.publish non autorisé après refresh → fallback INBOX")
+            rc_fb2, _, _ = _post(direct=False)
+            if rc_fb2 == 0:
+                log.info("📤 Upload TikTok OK en mode INBOX (fallback après refresh)")
+                return True, "ok_inbox_fallback"
         if _contains_spam_risk(blob2):
             log.error(f"🚫 Upload TikTok refusé après retry (spam risk): {TIKTOK_SPAM_RISK_KEY}")
             return False, "spam_risk"
@@ -418,7 +440,7 @@ def upload_to_tiktok_with_retry(final_mp4: str, python_exe: str = sys.executable
     # --- Tentative 3 : erreur non-token — on tente un refresh au cas où + retry
     log.warning("❌ Upload TikTok échoué (erreur inconnue). Tentative refresh + retry…")
     _refresh_token_ok(python_exe, log_path)
-    rc3, out3, err3 = _post()
+    rc3, out3, err3 = _post(direct=bool(caption))
     if rc3 == 0:
         log.info("📤 Upload TikTok OK après retry (erreur transitoire)")
         return True, "ok"

--- a/post_tiktok_inbox.py
+++ b/post_tiktok_inbox.py
@@ -22,6 +22,7 @@ load_dotenv()
 API_INIT_INBOX  = "https://open.tiktokapis.com/v2/post/publish/inbox/video/init/"
 API_INIT_DIRECT = "https://open.tiktokapis.com/v2/post/publish/video/init/"
 API_STATUS      = "https://open.tiktokapis.com/v2/post/publish/status/fetch/"
+API_CREATOR_INFO = "https://open.tiktokapis.com/v2/post/publish/creator_info/query/"
 
 MIB        = 1024 * 1024
 MIN_CHUNK  = 5  * MIB     # 5 MiB
@@ -34,6 +35,10 @@ def err(s):  print("[ERR]", s, flush=True)
 
 class AccessTokenInvalid(Exception):
     """Le token d'accès est invalide ou manquant dans la requête."""
+    pass
+
+class ScopeNotAuthorized(Exception):
+    """Le scope requis (video.publish) n'a pas été autorisé par l'utilisateur."""
     pass
 
 def human_bytes(n: int) -> str:
@@ -98,42 +103,69 @@ def compute_plan_with_override(total_size: int, chunk_mib: int) -> tuple[int,int
 
     return chunk_size, total_parts
 
-def build_post_info(args) -> dict | None:
+def build_post_info(args, creator_info: dict | None = None) -> dict | None:
     """
     Construit le bloc post_info pour un POST DIRECT.
-    Champs supportés (noms API) :
-      - privacy_level: PUBLIC_TO_EVERYONE | MUTUAL_FOLLOW_FRIENDS | FOLLOWER_OF_CREATOR | SELF_ONLY
-      - title
-      - disable_duet, disable_stitch, disable_comment
-      - video_cover_timestamp_ms
+    Valide le privacy_level contre les options retournées par creator_info (obligatoire).
     """
     if not args.direct:
         return None
+
+    privacy = args.privacy
+    if creator_info:
+        allowed = creator_info.get("privacy_level_options", [])
+        if allowed and privacy not in allowed:
+            log(f"Privacy '{privacy}' non disponible pour ce compte (options: {allowed}), fallback sur '{allowed[0]}'")
+            privacy = allowed[0]
+
     pi: dict = {
-        "privacy_level": args.privacy,
+        "privacy_level": privacy,
     }
     if args.caption:
-        pi["title"] = args.caption
-    if args.disable_duet:
+        pi["title"] = args.caption[:2200]  # max 2200 UTF-16 runes
+    if args.disable_duet or (creator_info and creator_info.get("duet_disabled")):
         pi["disable_duet"] = True
-    if args.disable_stitch:
+    if args.disable_stitch or (creator_info and creator_info.get("stitch_disabled")):
         pi["disable_stitch"] = True
-    if args.disable_comment:
+    if args.disable_comment or (creator_info and creator_info.get("comment_disabled")):
         pi["disable_comment"] = True
     if args.cover_ms is not None:
         pi["video_cover_timestamp_ms"] = args.cover_ms
     return pi
 
 def _raise_if_token_invalid(resp: requests.Response):
-    # TikTok renvoie HTTP 401 + {"error":{"code":"access_token_invalid", ...}}
+    # TikTok renvoie HTTP 401 + {"error":{"code":"access_token_invalid"|"scope_not_authorized", ...}}
     if resp.status_code == 401:
         try:
             j = resp.json()
         except Exception:
             j = {}
         code = ((j.get("error") or {}).get("code") or "").lower()
+        if "scope_not_authorized" in code:
+            raise ScopeNotAuthorized(resp.text)
         if "access_token_invalid" in code or "access token" in (j.get("error", {}).get("message","").lower()):
             raise AccessTokenInvalid(resp.text)
+
+
+def query_creator_info(token: str) -> dict:
+    """
+    Appelle /v2/post/publish/creator_info/query/ (obligatoire avant chaque post DIRECT).
+    Retourne les infos du créateur : privacy_level_options, max_video_post_duration_sec, etc.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=UTF-8",
+    }
+    r = requests.post(API_CREATOR_INFO, headers=headers, json={}, timeout=30)
+    _raise_if_token_invalid(r)
+    if r.status_code != 200:
+        err(f"creator_info HTTP {r.status_code}: {r.text}")
+        raise SystemExit(1)
+    data = r.json().get("data", {})
+    log(f"Creator: @{data.get('creator_username', '?')} — "
+        f"privacy={data.get('privacy_level_options', [])}, "
+        f"max_duration={data.get('max_video_post_duration_sec', '?')}s")
+    return data
 
 def init_file_upload(token: str,
                      video_size: int,
@@ -293,7 +325,29 @@ def main():
 
     log(f"Fichier: {video_path.name} ({human_bytes(total_size)}), chunk={human_bytes(chunk_size)}, parts={total_parts}")
 
-    post_info = build_post_info(args)
+    # 0) Query creator_info (obligatoire avant chaque post DIRECT, exigé par TikTok pour l'audit)
+    creator_info = None
+    if args.direct:
+        try:
+            creator_info = query_creator_info(token)
+            max_dur = creator_info.get("max_video_post_duration_sec", 0)
+            if max_dur and total_size > 0:
+                # Vérification informative de la durée (on n'a pas la durée exacte ici)
+                log(f"Durée max autorisée par le créateur: {max_dur}s")
+        except ScopeNotAuthorized:
+            err("scope video.publish non autorisé — relance auth_tiktok_token_manager.py avec le nouveau scope")
+            raise SystemExit(2)
+        except AccessTokenInvalid:
+            log("Token expiré lors de creator_info, refresh en cours...")
+            try:
+                subprocess.run([sys.executable, "auth_tiktok_refresh.py"], check=True)
+            except subprocess.CalledProcessError as sube:
+                raise SystemExit(f"[ERR] Échec refresh: {sube}") from sube
+            load_dotenv(override=True)
+            token = ensure_token()
+            creator_info = query_creator_info(token)
+
+    post_info = build_post_info(args, creator_info=creator_info)
 
     # 1) INIT (INBOX vs DIRECT) — avec auto refresh token si 401/access_token_invalid
     try:
@@ -302,10 +356,12 @@ def main():
             direct=args.direct,
             post_info=post_info
         )
+    except ScopeNotAuthorized:
+        err("scope video.publish non autorisé — relance auth_tiktok_token_manager.py avec le nouveau scope")
+        raise SystemExit(2)
     except AccessTokenInvalid as e:
         err("Token invalide/expiré détecté à l'INIT. Lancement de auth_refreshtoken.py…")
         try:
-            # Utilise le même interpréteur Python actif
             subprocess.run([sys.executable, "auth_tiktok_refresh.py"], check=True)
         except subprocess.CalledProcessError as sube:
             raise SystemExit(f"[ERR] Échec auth_refreshtoken.py: {sube}") from sube


### PR DESCRIPTION
- Add video.publish to default scopes in auth_tiktok_token_manager.py
- Save refresh_token in .env during initial auth
- Add query_creator_info() call before each direct post (required by TikTok audit)
- Validate privacy_level against creator's allowed options
- Detect scope_not_authorized errors distinctly from token issues
- Auto-fallback from DIRECT to INBOX when scope not approved
- Add GitHub Pages (docs/) for TikTok app review: landing, ToS, privacy policy